### PR TITLE
Fixes to_json method contract

### DIFF
--- a/lib/chef-api/resources/base.rb
+++ b/lib/chef-api/resources/base.rb
@@ -927,7 +927,7 @@ module ChefAPI
     #
     # @return [String]
     #
-    def to_json
+    def to_json(*)
       JSON.fast_generate(to_hash)
     end
 


### PR DESCRIPTION
Method `to_json` should optionally accept the state. Otherwise when you do something like `[<#resource1...>, <#resource2>].to_json` you receive 

```
ArgumentError - wrong number of arguments (1 for 0):
        /home/ares/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/chef-api-0.5.0/lib/chef-api/resources/base.rb:930:in `to_json'
```