### PR TITLE
Add required fields to role schema

### DIFF
--- a/lib/chef-api/resources/role.rb
+++ b/lib/chef-api/resources/role.rb
@@ -5,7 +5,6 @@ module ChefAPI
     schema do
       attribute :name,                type: String, primary: true, required: true
       attribute :json_class,          type: String, default: "Chef::Role"
-      attribute :chef_type,           type: String, default: "role"
       attribute :description,         type: String
       attribute :default_attributes,  type: Hash,   default: {}
       attribute :override_attributes, type: Hash,   default: {}

--- a/lib/chef-api/resources/role.rb
+++ b/lib/chef-api/resources/role.rb
@@ -4,6 +4,8 @@ module ChefAPI
 
     schema do
       attribute :name,                type: String, primary: true, required: true
+      attribute :json_class,          type: String, default: "Chef::Role"
+      attribute :chef_type,           type: String, default: "role"
       attribute :description,         type: String
       attribute :default_attributes,  type: Hash,   default: {}
       attribute :override_attributes, type: Hash,   default: {}


### PR DESCRIPTION
Chef expect the role to have a classifier fields.

Failure to provide them results in following error during converge:

```
================================================================================       
Error expanding the run_list:       
================================================================================       
       
Unexpected Error:       
-----------------       
NoMethodError: undefined method `run_list_for' for #<Hash:0x000000031f6280>       
       
[2015-06-29T14:27:51+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out       
Chef Client failed. 0 resources updated in 4.265276004 seconds       
[2015-06-29T14:27:51+00:00] ERROR: undefined method `run_list_for' for #<Hash:0x000000031f6280>       
[2015-06-29T14:27:51+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)    

```