### PR TITLE
Do not call #chomp on encrypted canonical request

### DIFF
--- a/lib/chef-api/authentication.rb
+++ b/lib/chef-api/authentication.rb
@@ -227,7 +227,7 @@ module ChefAPI
     # @return [String]
     #
     def encrypted_request
-      canonical_key.private_encrypt(canonical_request).chomp
+      canonical_key.private_encrypt(canonical_request)
     end
 
     #


### PR DESCRIPTION
Whether or not canonical_request ends in a newline is indistinguishable
from random (we hope!).  Chomp'ing here results in some number of API calls
to fail with a bad_sig error.