### PR TITLE
Don't set nil `JSON.create_id` as it's unnecessary in recent versions of the JSON library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChefAPI Changelog
 
+## v0.7.1 (2016-12-13)
+
+- Don't set nil `JSON.create_id` as it's unnecessary in recent versions
+  of the JSON library
+
 ## v0.6.0 (2016-05-05)
 
 - Remove support for Ruby 1.9

--- a/lib/chef-api.rb
+++ b/lib/chef-api.rb
@@ -3,9 +3,6 @@ require 'logify'
 require 'pathname'
 require 'chef-api/version'
 
-# Do not inflate JSON objects
-JSON.create_id = nil
-
 module ChefAPI
   autoload :Authentication,  'chef-api/authentication'
   autoload :Boolean,         'chef-api/boolean'

--- a/lib/chef-api/version.rb
+++ b/lib/chef-api/version.rb
@@ -1,3 +1,3 @@
 module ChefAPI
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end


### PR DESCRIPTION
Remove `JSON.create_id = nil` as it is no longer required with the current JSON lib in Ruby. (That line also broke if Oj was used as the JSON parser, as it requires a string argument.)
