### PR TITLE
Change Search docs URI to docs.chef.io

### DIFF
--- a/lib/chef-api/resources/search.rb
+++ b/lib/chef-api/resources/search.rb
@@ -10,7 +10,7 @@ module ChefAPI
 
     class << self
       #
-      # About search : http://docs.opscode.com/essentials_search.html
+      # About search : https://docs.chef.io/chef_search.html
       #
       # @param [String] index
       #   the name of the index to search


### PR DESCRIPTION
This trivial PR changes the docs to avoid a 404.