### PR TITLE
Docs: chef.io URLs in code comments

### DIFF
--- a/lib/chef-api/connection.rb
+++ b/lib/chef-api/connection.rb
@@ -7,7 +7,7 @@ module ChefAPI
   #
   # Connection object for the ChefAPI API.
   #
-  # @see http://docs.opscode.com/api_chef_server.html
+  # @see https://docs.chef.io/api_chef_server.html
   #
   class Connection
     class << self

--- a/lib/chef-api/resources/partial_search.rb
+++ b/lib/chef-api/resources/partial_search.rb
@@ -10,7 +10,7 @@ module ChefAPI
 
     class << self
       #
-      # About search : http://docs.opscode.com/essentials_search.html
+      # About search : https://docs.chef.io/chef_search.html
       #
       # @param [String] index
       #   the name of the index to search


### PR DESCRIPTION
This PR sets the 2 remaining docs.opscode.com URLs right. One was fixed in #49 - this takes care of the rest.