### PR TITLE
Spec: Avoid RSpec warning

### DIFF
--- a/spec/unit/resources/base_spec.rb
+++ b/spec/unit/resources/base_spec.rb
@@ -20,7 +20,9 @@ module ChefAPI
 
     describe '.collection_path' do
       it 'raises an exception if the collection name is not set' do
-        expect { described_class.collection_path }.to raise_error
+        expect {
+          described_class.collection_path
+        }.to raise_error(ArgumentError, 'collection_path not set for Class')
       end
 
       it 'sets the collection name' do


### PR DESCRIPTION
This PR avoids an RSpec warning by being extra specific in the test.