### PR TITLE
support a configurable read_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ ChefAPI.configure do |config|
   config.proxy_password = 'password'
   config.proxy_address  = 'my.proxy.server' # or 10.0.0.50
   config.proxy_port     = '8080'
+
+  # If you want to make queries that return a very large result chef, you might
+  # need to adjust the timeout limits for the network request. (NOTE: time is
+  # given in seconds).
+  config.read_timeout = 120
 end
 ```
 

--- a/lib/chef-api/configurable.rb
+++ b/lib/chef-api/configurable.rb
@@ -23,6 +23,7 @@ module ChefAPI
           :ssl_pem_file,
           :ssl_verify,
           :user_agent,
+          :read_timeout,
         ]
       end
     end

--- a/lib/chef-api/connection.rb
+++ b/lib/chef-api/connection.rb
@@ -253,6 +253,11 @@ module ChefAPI
       connection = Net::HTTP.new(uri.host, uri.port,
         proxy_address, proxy_port, proxy_username, proxy_password)
 
+      # Large or filtered result sets can take a long time to return, so allow
+      # setting a longer read_timeout for our client if we want to make an
+      # expensive request.
+      connection.read_timeout = read_timeout if read_timeout
+
       # Apply SSL, if applicable
       if uri.scheme == 'https'
         # Turn on SSL

--- a/lib/chef-api/defaults.rb
+++ b/lib/chef-api/defaults.rb
@@ -181,6 +181,17 @@ module ChefAPI
           %w[t y].include?(ENV['CHEF_API_SSL_VERIFY'].downcase[0]) || config['CHEF_API_SSL_VERIFY']
         end
       end
+
+      #
+      # Network request read timeout in seconds (default: 60)
+      #
+      # @return [Integer, nil]
+      #
+      def read_timeout
+        timeout_from_env = ENV['CHEF_API_READ_TIMEOUT'] || config['CHEF_API_READ_TIMEOUT']
+
+        Integer(timeout_from_env) unless timeout_from_env.nil?
+      end
     end
   end
 end


### PR DESCRIPTION
as a followup to #61, this adds support for a configurable read_timeout because certain chef queries can take more than the default of 60s to return a result of there are lots of nodes. 

/cc @sethvargo @tas50 @annih
/fyi @grosser @jonmoter 